### PR TITLE
added pgpass search as for PostgreSQL standard approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # PgPass
 
+1.0.1
+  - added pgpass search as for PostgreSQL standard approach
+  - added docker-compose test environment 
+  - changed org.apache.maven.plugins version to 3.6.1->3.9.0
+
 1.0.0
   - added missing javadocs, public release.
 
@@ -8,3 +13,4 @@
 
 0.0.2
   - added getAll methods, minor changes.
+

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ PgPass.get(Path pgPassPath)
 PgPass.getPgPassPath()
 ```
 
+#### Docker Testing
+```bash
+docker-compose -f docker-compose.test.yml run --rm t1
+```
+
+
 #### License
 
 This application is licensed under the Apache License, Version 2.0. See [LICENCE](LICENSE) for details.

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  t1:
+    container_name: pgpass
+    image: maven:3.5.3-jdk-8-alpine
+    volumes:
+      - ${HOME}/.m2:/root/.m2
+      - ./:/wd
+    working_dir: /wd
+    command: ["mvn", "clean", "install"]

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                 </configuration>
-                <version>3.6.1</version>
+                <version>3.9.0</version>
             </plugin>
         </plugins>
     </build>

--- a/src/main/java/ru/taximaxim/pgpass/PgPass.java
+++ b/src/main/java/ru/taximaxim/pgpass/PgPass.java
@@ -122,15 +122,21 @@ public class PgPass {
     }
 
     /**
-     * Return pgpass default location
+     * Return pgpass default location as for standard postgreSQL cascade approach:
+     * - check from env var: PGPASSFILE
+     * - check for user home folder
      *
-     * @return pgpass default location
+     * @return pgpass default location, null if not found
      */
     public static Path getPgPassPath() {
-        Path path = Paths.get(System.getProperty("user.home")).resolve(Paths.get(".pgpass"));
-        String os = System.getProperty("os.name").toUpperCase();
-        if (os.contains("WIN")) {
-            path = Paths.get(System.getenv("APPDATA")).resolve(Paths.get("postgresql", "pgpass.conf"));
+        Path path;
+        String OS = System.getProperty("os.name").toLowerCase();
+        if (System.getenv().containsKey("PGPASSFILE")) {
+            path = Paths.get(System.getenv("PGPASSFILE"));
+        } else if (OS.contains("win")) {
+            path = Paths.get(System.getProperty("APPDATA")).resolve(Paths.get("postgresql", "pgpass.conf"));
+        } else {
+            path = Paths.get(System.getProperty("user.home")).resolve(Paths.get(".pgpass"));
         }
         return path;
     }


### PR DESCRIPTION
I would like to add the PGPASSFILE env variable search as for standard PostgreSQL approach.

Motivation is that the use of the env var is more handy.

To be able to properly test this, env must be managed and files have to be moved, so a simple docker has been added and the  org.apache.maven.plugins has been updated cause previous version has not working. 

This partially solve https://github.com/technology16/pgpass/issues/1